### PR TITLE
Update AIP File To Compile Under Freeware Version

### DIFF
--- a/ais/shakeitoff.aip
+++ b/ais/shakeitoff.aip
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<DOCUMENT Type="Advanced Installer" CreateVersion="18.7" version="18.9" Modules="architect" RootPath="." Language="en" Id="{383E7A60-3042-4466-B614-6B3344E6E182}">
+<DOCUMENT Type="Advanced Installer" CreateVersion="18.7" version="18.9" Modules="freeware" RootPath="." Language="en" Id="{383E7A60-3042-4466-B614-6B3344E6E182}">
   <COMPONENT cid="caphyon.advinst.msicomp.MsiPropsComponent">
     <ROW Property="AI_BITMAP_DISPLAY_MODE" Value="0"/>
     <ROW Property="AI_CURRENT_YEAR" Value="2021" ValueLocId="-"/>


### PR DESCRIPTION
By updating this file, you remove the line (Evaluation Version) from being added to all the binaries, making them smaller, and you also prevent Advanced Installer from prompting you to start a license trial and thinking that you need a valid license or license trial to compile the MSI when in reality you aren't using any of the paid features and Advanced Installer is just reading this part of the XML file and going "Oh the file says this so we must need a valid license file or trial to compile the product".

Don't ask me why the product doesn't have a better way of determining the requirements for licensing, I really have no idea why it decided that a line in an XML file is the primary determinant of what feature are required as I know there are better ways to do things, but it is what it is.

This also allows people to be compliant with the license requirements which state that:

```
2.2 Trial Period License. You may download and use the Software for free for thirty (30) days after installation ("Trial Period"). During the Trial Period, Caphyon grants You a limited, non-exclusive, non-transferable, non-renewable license to copy and use the Software for evaluation purposes only and not for any commercial use. At Caphyon's discretion, Caphyon may provide limited support through email or discussion forums at Caphyon web site. The evaluation copy of the Software contains a feature that will automatically disable the Software at the end of Trial Period. Caphyon will have no liability to you if this feature disables the Software.
```

Note that it explicitly states for evaluation purpose only and not for commercial use, whereas the freeware version states:

```
2.1 Freeware Features License. Caphyon grants you an unlimited license to use the Freeware Features of the Software. The install packages created using only the Freeware Features can be freely redistributed and used both in commercial and non-commercial purpose.
```

Or as a TLDR: we aren't using any paid features but due to this file it thinks we are. Since the freeware version doesn't impose any restrictions and we aren't using any paid features that require a paid license this kills two birds with one stone by complying with licensing and also prevents people accidentally starting a trial when they don't need to.